### PR TITLE
Fix: npm lock error - disable package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+.env
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+package-lock.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+use-lockfile-v3=false
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "heroku-postbuild": "echo 'Skip build on Heroku'"
   },
   "engines": {
     "node": "20.x",


### PR DESCRIPTION
## 🔧 Fix: Error de npm lock en Heroku

Este PR soluciona el error `npm ci can only install packages when package.json and package-lock.json are in sync`.

### Problema:
Heroku está intentando usar `npm ci` que requiere que package-lock.json esté sincronizado con package.json, pero el archivo lock que teníamos no estaba actualizado.

### Solución implementada:

1. **Agregado `.npmrc`**:
   ```
   use-lockfile-v3=false
   package-lock=false
   ```
   - Esto le dice a npm que NO use package-lock.json
   - Fuerza a Heroku a usar `npm install` en lugar de `npm ci`

2. **Actualizado `.gitignore`**:
   - Añadido `package-lock.json` para evitar futuros conflictos
   - Así no se subirá accidentalmente un archivo lock desactualizado

3. **Actualizado `package.json`**:
   - Agregado script `heroku-postbuild` vacío
   - Mantenidas las versiones de Node 20.x y npm 10.x

### Por qué funciona:
- Al desactivar el uso de package-lock.json, Heroku usará `npm install` que instala las dependencias basándose solo en package.json
- Esto evita los errores de sincronización entre package.json y package-lock.json

### Para aplicar los cambios:
1. Merge este PR
2. En Heroku, haz click en "Deploy Branch" otra vez
3. El build debería completarse sin errores esta vez

🎯 **Este es el fix definitivo para el error de npm lock!**